### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,20 @@ Peregrine has been tested on Ubuntu 18.04 and Arch Linux but should work on any
 POSIX-y OS. It requires C++20 support (GCC version >= 9.2.1). Additionally, the
 tests require [UnitTest++](https://github.com/unittest-cpp/unittest-cpp).
 
+Ubuntu 18.04 prerequisites:
+```
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt install g++-10 libunittest++-dev
+```
+
 To build Peregrine:
 
 ```
 $ git clone https://github.com/pdclab/Peregrine.git
 $ cd Peregrine
 $ source tbb2020/bin/tbbvars.sh intel64
-$ make -j
+$ make -j CC=g++-10
 $ bin/test
 ```
 


### PR DESCRIPTION
Add Ubuntu 18.04 dependencies, add `CC` option to `make`.

I have compiled and tested the library successfully on Ubuntu 18.04 using both `g++-9` and `g++-10`.

Here's the versions of `g++` I have tested:

*  `g++-9`: `g++-9 (Ubuntu 9.3.0-11ubuntu0~18.04.1) 9.3.0`
*  `g++-10`: `g++-10 (Ubuntu 10.1.0-2ubuntu1~18.04) 10.1.0`

To  install both `g++-9` and `g++-10` on Ubuntu 18.04, you need to add the [toolchain-r ppa][toolchain-r-ppa].

Furthermore, the default version of `g++` is the `g++-7` (in my case, `Ubuntu 7.5.0-3ubuntu1~18.04`). So when launching `make` this will probably fail because `g++-7` doesn't support `-std=c++2a`.

Here's the error that I get:
```
$ make           
make -C ./core/bliss-0.73
make[1]: Entering directory '/tmp/peregrine/peregrine/core/bliss-0.73'
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o bliss.o bliss.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o defs.o defs.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o graph.o graph.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o partition.o partition.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o orbit.o orbit.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o uintseqhash.o uintseqhash.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o heap.o heap.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o timer.o timer.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o utils.o utils.cc
g++ -I. -g -Wall --pedantic -O9 -fPIC -c -o bliss_C.o bliss_C.cc
rm -f libbliss.a
ar cr libbliss.a defs.o graph.o partition.o orbit.o uintseqhash.o heap.o timer.o utils.o bliss_C.o
ranlib libbliss.a
g++ -I. -g -Wall --pedantic -O9 -fPIC -o bliss bliss.o defs.o graph.o partition.o orbit.o uintseqhash.o heap.o timer.o utils.o bliss_C.o 
make[1]: Leaving directory '/tmp/peregrine/peregrine/core/bliss-0.73'
g++ -c core/DataGraph.cc -o core/DataGraph.o -O3 -std=c++2a -Wall -Wextra -Wpedantic -fPIC -fconcepts -I/tmp/peregrine/peregrine/core/ -Itbb2020/include
g++: error: unrecognized command line option ‘-std=c++2a’; did you mean ‘-std=c++03’?
Makefile:15: recipe for target 'core/DataGraph.o' failed
make: *** [core/DataGraph.o] Error 1
```

To avoid this problem without modifying the `Makefile`, you can pass the `CC` variable when invoking `make`:
```
make -j CC=g++-10
```
so I have updated the instructions accordingly.


[toolchain-r-ppa]: https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test